### PR TITLE
Response.isDeprecated() not working correctly

### DIFF
--- a/src/main/java/gbsio/esiclient/internal/hooks/response/impl/DeprecationDetectionHook.java
+++ b/src/main/java/gbsio/esiclient/internal/hooks/response/impl/DeprecationDetectionHook.java
@@ -16,7 +16,7 @@ public class DeprecationDetectionHook implements HeadersHook {
 
     @Override
     public void process(final HttpResponseHeaders headers, RawContentResponse.Builder builder) {
-        if (headers.getHeaders().contains("warning") && headers.getHeaders().get("warning").equals("299 - This route is deprecated.")) {
+        if (headers.getHeaders().contains("warning") && headers.getHeaders().getAll("warning").stream().anyMatch(s -> s.startsWith("299"))) {
             builder.setDeprecated(true);
         }
     }

--- a/src/test/java/gbsio/functional/client/http/hooks/response/internal/DeprecationDetectionHookTest.java
+++ b/src/test/java/gbsio/functional/client/http/hooks/response/internal/DeprecationDetectionHookTest.java
@@ -1,61 +1,38 @@
 package gbsio.functional.client.http.hooks.response.internal;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.google.common.collect.ImmutableMap;
-import gbsio.esiclient.api.domain.response.search.SearchResults;
+import com.google.common.collect.ImmutableList;
+import gbsio.esiclient.api.domain.response.universe.SystemKillData;
 import gbsio.esiclient.api.request.specific.GetRequest;
 import gbsio.esiclient.api.response.Response;
 import gbsio.functional.FunctionalTestHarness;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-import java.util.Map;
-import java.util.Optional;
-
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DeprecationDetectionHookTest extends FunctionalTestHarness {
     @Test
-    void checkDeprecated() throws IOException {
-        final Integer characterID = Integer.valueOf(getProperty("querns_id"));
-        final String authenticationToken = getProperty("querns_token");
-        final Response<SearchResults> response = getClient().sendRequest(new DeprecatedRequest(characterID, authenticationToken)).join();
+    void checkDeprecated() {
+        final Response<ImmutableList<SystemKillData>> response = getClient().sendRequest(new DeprecatedRequest()).join();
 
         assertTrue(response.isDeprecated());
     }
 
-    private class DeprecatedRequest implements GetRequest<SearchResults> {
-        private final int characterID;
-        private final String authenticationToken;
+    private class DeprecatedRequest implements GetRequest<ImmutableList<SystemKillData>>{
 
-        private DeprecatedRequest(final int characterID, final String authenticationToken) {
-            this.characterID = characterID;
-            this.authenticationToken = authenticationToken;
-        }
 
-        @Override
-        public Map<String, Object> getQueryParameters() {
-            //noinspection SpellCheckingInspection
-            return ImmutableMap.of(
-                "categories", "character",
-                "search", "Querns"
-            );
-        }
+        private DeprecatedRequest() {}
 
         @Override
         public String getURL() {
-            return String.format("/v2/characters/%d/search/", characterID);
+            return "/v1/universe/system_kills/";
         }
 
+
         @Override
-        public TypeReference<SearchResults> getExpectedType() {
-            return new TypeReference<SearchResults>() {
+        public TypeReference<ImmutableList<SystemKillData>> getExpectedType() {
+            return new TypeReference<ImmutableList<SystemKillData>>() {
             };
-        }
-
-        @Override
-        public Optional<String> getAccessToken() {
-            return Optional.of(authenticationToken);
         }
     }
 }


### PR DESCRIPTION
- Deprecation detection not working because CCP changed the 299 message (no more trailing dot)
- Check for multiple "Warning" headers
- Change deprecation test to used unauthenticated call